### PR TITLE
Corresponding v13 Babele update

### DIFF
--- a/scripts/babele-register.js
+++ b/scripts/babele-register.js
@@ -1,35 +1,9 @@
-Hooks.once('init', () => {
-	if(typeof Babele !== 'undefined') {
-		Babele.get().register({
-			module: 'CoC7kr',
-			lang: 'ko',
-			dir: 'compendium'
-		});
-
-		Babele.get().registerConverters({
-			"weight": (value) => { return parseInt(value)/2 },
-			"range": (range) => {
-				if(range) {
-					if(range.units === 'ft') {
-						if(range.long) {
-							range = mergeObject(range, { long: Math.floor(range.long*0.3) });
-						}
-						return mergeObject(range, { value: Math.floor(range.value*0.3) });
-					}
-					if(range.units === 'mi') {
-						if(range.long) {
-							range = mergeObject(range, { long: Math.floor(range.long*1.5) });
-						}
-						return mergeObject(range, { value: range.value*1.5 });
-					}
-					return range;
-				}
-			}
-		});
-
-		CONFIG.DND5E.encumbrance.currencyPerWeight = 100;
-		CONFIG.DND5E.encumbrance.strMultiplier = 7.5;
-	}
+Hooks.once('babele.init', (babele) => {
+    babele.register({
+		module: 'CoC7kr',
+		lang: 'ko',
+		dir: 'compendium'
+	});
 });
 
 Hooks.on('preCreateScene', (scene) => {


### PR DESCRIPTION
Updated Babele registration to use 'babele.init' hook and removed old registration logic.